### PR TITLE
await the promise

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -11,7 +11,7 @@ export let meta: MetaFunction = () => {
 };
 
 export const loader: LoaderFunction = async ({ request }) => {
-  const user = getUser(request);
+  const user = await getUser(request);
   return {
     user
   }


### PR DESCRIPTION
This will fix your issue. What's happening is we call `getUser` and return a `user` which is a promise. So by now Remix has moved on from the loader. Then when the uncaught error is thrown, it makes the server fall over.

We could probably make the server more resilient to this sort of thing.